### PR TITLE
Reference auto-generated password and make database private

### DIFF
--- a/apis/composition.yaml
+++ b/apis/composition.yaml
@@ -21,6 +21,10 @@ spec:
             engineVersion: "12"
             skipFinalSnapshotBeforeDeletion: true
             publiclyAccessible: true
+            passwordSecretRef:
+              name: upbound-provider-aws-password
+              namespace: upbound-system
+              key: password
           writeConnectionSecretToRef:
             namespace: upbound-system
       patches:

--- a/apis/composition.yaml
+++ b/apis/composition.yaml
@@ -20,7 +20,7 @@ spec:
             engine: postgres
             engineVersion: "12"
             skipFinalSnapshotBeforeDeletion: true
-            publiclyAccessible: true
+            publiclyAccessible: false
             passwordSecretRef:
               name: upbound-provider-aws-password
               namespace: upbound-system


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Adds a reference to the auto-generated password Secret such that it can
be used as the root password for the database.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Makes database private while auto-generated passwords are being used.
Note that this field alone does not necessarily indicate that the
database is publicly accessible.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

Created claim with referenced password secret present in cluster.