### PR TITLE
rds: use auto password generation feature from the latest provider-aws

### DIFF
--- a/apis/composition.yaml
+++ b/apis/composition.yaml
@@ -21,8 +21,8 @@ spec:
             engineVersion: "12"
             skipFinalSnapshot: true
             publiclyAccessible: false
+            autoGeneratePassword: true
             passwordSecretRef:
-              name: upbound-provider-aws-password
               namespace: upbound-system
               key: password
           writeConnectionSecretToRef:
@@ -34,6 +34,12 @@ spec:
             - type: string
               string:
                 fmt: "%s-postgresql"
+        - fromFieldPath: "metadata.uid"
+          toFieldPath: "spec.forProvider.passwordSecretRef.name"
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-input"
         - fromFieldPath: "spec.parameters.region"
           toFieldPath: "spec.forProvider.region"
           transforms:

--- a/crossplane.yaml
+++ b/crossplane.yaml
@@ -22,4 +22,4 @@ spec:
     version: ">=v1.7.0-0"
   dependsOn:
     - provider: xpkg.upbound.io/upbound/provider-aws
-      version: ">=v0.24.0"
+      version: ">=v0.32.0"


### PR DESCRIPTION
### Description of your changes

This should make this configuration work without any pre-work like secret creation.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Local kind cluster with given example.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
